### PR TITLE
Reverted componentDidUpdate to componentWillUpdate, fixing the price total view.

### DIFF
--- a/components/PriceTotalView.js
+++ b/components/PriceTotalView.js
@@ -21,7 +21,9 @@ class PriceTotalView extends React.Component {
         this.props.listener.onUpdate = this.handleCheckboxUpdate;
     }
 
-    componentDidUpdate(nextProps, nextState, nextContext) {
+    // This function will be deprecated in React 17.x, so a new solution must be found if we are to use a newer version
+    //  of React, but for now it is fine.
+    componentWillUpdate(nextProps, nextState, nextContext) {
         nextProps.listener.onUpdate = this.handleCheckboxUpdate;
     }
 


### PR DESCRIPTION
Fixes #37 
If we want to update to a React version later than 17.x, we will have to find a way to change this. For now, though, it is fine.